### PR TITLE
configs: Setup soong namespaces for TARGET_USE_QTI_BT_STACK

### DIFF
--- a/configs/BoardConfigSoong.mk
+++ b/configs/BoardConfigSoong.mk
@@ -92,3 +92,7 @@ SOONG_CONFIG_aospGlobalVars_uses_camera_parameter_lib := $(TARGET_SPECIFIC_CAMER
 ifneq ($(filter $(UM_PLATFORMS),$(TARGET_BOARD_PLATFORM)),)
 SOONG_CONFIG_aospQcomVars_qcom_soong_namespace := $(QCOM_SOONG_NAMESPACE)
 endif
+
+ifneq ($(TARGET_USE_QTI_BT_STACK),true)
+PRODUCT_SOONG_NAMESPACES += packages/apps/Bluetooth
+endif #TARGET_USE_QTI_BT_STACK

--- a/configs/common.mk
+++ b/configs/common.mk
@@ -79,7 +79,9 @@ PRODUCT_VENDOR_MOVE_ENABLED := true
 DISABLE_EAP_PROXY := true
 
 # NameSpaces
+ifeq ($(TARGET_USE_QTI_BT_STACK),true)
 PRODUCT_SOONG_NAMESPACES += vendor/qcom/opensource/commonsys/packages/apps/Bluetooth
+endif #TARGET_USE_QTI_BT_STACK
 PRODUCT_SOONG_NAMESPACES += vendor/qcom/opensource/commonsys/system/bt/conf
 
 # QCOM


### PR DESCRIPTION
To opt-in for QTI BT addons, enable TARGET_USE_QTI_BT_STACK in BoardConfig.mk

Reference: [https://github.com/LineageOS/android_vendor_qcom_opensource_bluetooth-commonsys-intf/blob/lineage-18.0/bt-system-opensource-product.mk]

Change-Id: I6bf3e1dda6fe5dc66f6fafdb32a1daecb9616c84
Signed-off-by: DennySPb <dennyspb@gmail.com>
Signed-off-by: Md Abu Talha <rokusenpai06@gmail.com>