### PR TITLE
soong: add TARGET_HAS_MEMFD_BACKPORT conditional

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -95,6 +95,23 @@ vendor_init {
 }
 
 soong_config_module_type {
+    name: "has_memfd_backport",
+    module_type: "cc_defaults",
+    config_namespace: "aospGlobalVars",
+    bool_variables: ["has_memfd_backport"],
+    properties: ["cppflags"],
+}
+
+has_memfd_backport {
+    name: "has_memfd_backport_defaults",
+    soong_config_variables: {
+        has_memfd_backport: {
+            cppflags: ["-DHAS_MEMFD_BACKPORT"],
+        },
+    },
+}
+
+soong_config_module_type {
     name: "surfaceflinger_udfps_lib",
     module_type: "cc_defaults",
     config_namespace: "aospGlobalVars",

--- a/configs/BoardConfigSoong.mk
+++ b/configs/BoardConfigSoong.mk
@@ -31,6 +31,7 @@ SOONG_CONFIG_aospGlobalVars += \
     target_ld_shim_libs \
     target_process_sdk_version_override \
     target_surfaceflinger_udfps_lib
+    has_memfd_backport \
 
 # Set default values
 TARGET_INIT_VENDOR_LIB ?= vendor_init
@@ -41,3 +42,4 @@ SOONG_CONFIG_aospGlobalVars_target_init_vendor_lib := $(TARGET_INIT_VENDOR_LIB)
 SOONG_CONFIG_aospGlobalVars_target_ld_shim_libs := $(subst $(space),:,$(TARGET_LD_SHIM_LIBS))
 SOONG_CONFIG_aospGlobalVars_target_process_sdk_version_override := $(TARGET_PROCESS_SDK_VERSION_OVERRIDE)
 SOONG_CONFIG_aospGlobalVars_target_surfaceflinger_udfps_lib := $(TARGET_SURFACEFLINGER_UDFPS_LIB)
+SOONG_CONFIG_aospGlobalVars_has_memfd_backport := $(TARGET_HAS_MEMFD_BACKPORT)


### PR DESCRIPTION
This commit fixed:
error: art/libartbase/Android.bp:17:1: "libartbase_defaults" depends on
undefined module "has_memfd_backport_defaults

Without this variable give error while building