### PR TITLE
permissions: add missing wallpaper priv-app permissions for vanilla builds

### DIFF
--- a/configs/common.mk
+++ b/configs/common.mk
@@ -107,6 +107,10 @@ PRODUCT_COPY_FILES += \
 # Telephony
 $(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base_telephony.mk)
 
+# priv-app permissions
+PRODUCT_COPY_FILES += \
+   vendor/404/prebuilt/common/etc/permissions/privapp-permissions-google.xml:$(TARGET_COPY_OUT_SYSTEM_EXT)/etc/permissions/privapp-permissions-google.xml
+
 # World APN list
 PRODUCT_COPY_FILES += \
     vendor/404/prebuilt/etc/apns-conf.xml:$(TARGET_COPY_OUT_SYSTEM)/etc/apns-conf.xml

--- a/prebuilt/common/etc/permissions/privapp-permissions-google.xml
+++ b/prebuilt/common/etc/permissions/privapp-permissions-google.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2018 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+
+<!--
+This XML file declares which signature|privileged permissions should be granted to privileged
+applications in /product GMS or Google-branded devices.
+It allows additional grants on top of privapp-permissions-platform.xml
+-->
+<permissions>
+    <privapp-permissions package="com.android.wallpaper">
+        <permission name="android.permission.CHANGE_OVERLAY_PACKAGES"/>
+        <permission name="android.permission.SET_WALLPAPER_COMPONENT"/>
+        <permission name="android.permission.WRITE_SECURE_SETTINGS"/>
+        <permission name="android.permission.MODIFY_DAY_NIGHT_MODE"/>
+    </privapp-permissions>
+</permissions>


### PR DESCRIPTION
10-15 05:18:57.951  1287  1287 W PackageManager: Privileged permission android.permission.SET_WALLPAPER_COMPONENT for package com.google.android.apps.wallpaper (/system/system_ext/priv-app/WallpaperPickerGoogleRelease) not in privapp-permissions allowlist 10-15 05:18:57.951  1287  1287 W PackageManager: Privileged permission android.permission.BIND_WALLPAPER for package com.google.android.apps.wallpaper (/system/system_ext/priv-app/WallpaperPickerGoogleRelease) not in privapp-permissions allowlist 10-15 05:18:57.951  1287  1287 W PackageManager: Privileged permission android.permission.CHANGE_OVERLAY_PACKAGES for package com.google.android.apps.wallpaper (/system/system_ext/priv-app/WallpaperPickerGoogleRelease) not in privapp-permissions allowlist 10-15 05:18:57.951  1287  1287 W PackageManager: Privileged permission android.permission.WRITE_SECURE_SETTINGS for package com.google.android.apps.wallpaper (/system/system_ext/priv-app/WallpaperPickerGoogleRelease) not in privapp-permissions allowlist

Signed-off-by: karthik1896 <karthik1896@outlook.com>